### PR TITLE
[Deepspeed] Fix: The Qwen2_5VL model use the Deepspeed training backend during grpo training.

### DIFF
--- a/rllava/engine/train/accelerator.py
+++ b/rllava/engine/train/accelerator.py
@@ -188,8 +188,9 @@ class HFAccelerator(TrainEngine):
     def save_state(self, model, optimizer, lr_scheduler, checkpoint_path):
         self.accelerator.save_state(checkpoint_path)
 
-    def backward(self, loss):
-        self.accelerator.backward(loss)
+    def backward(self, loss, is_last_step: bool = True):
+        with self.accelerator.accumulate(model):
+            self.accelerator.backward(loss)
 
     def clip_grad_norm_(self, model, max_norm):
         return self.accelerator.clip_grad_norm_(model.parameters(), max_norm)

--- a/rllava/engine/train/base.py
+++ b/rllava/engine/train/base.py
@@ -52,7 +52,7 @@ class TrainEngine:
     def save_state(self, model, optimizer, lr_scheduler, checkpoint_path):
         raise NotImplementedError("save_state is not implemented")
     
-    def backward(self, loss):
+    def backward(self, loss, is_last_step: bool = True):
         raise NotImplementedError("backward is not implemented")
 
     def optimizer_step(self):

--- a/rllava/engine/train/fsdp.py
+++ b/rllava/engine/train/fsdp.py
@@ -246,7 +246,8 @@ class FSDPAccelerator(TrainEngine):
         if self.fsdp_config.offload_optimizer:
             self.offload_fsdp_optimizer(optimizer)
 
-    def backward(self, loss: torch.Tensor):
+    def backward(self, loss: torch.Tensor, is_last_step: bool = True):
+        # is_last_step is ignored for FSDP, only used by DeepSpeed
         loss.backward()
 
     def get_fsdp_state_ctx(self, model, state_type, state_cfg, optim_cfg):

--- a/rllava/model/builder.py
+++ b/rllava/model/builder.py
@@ -132,14 +132,31 @@ def build_optimizer(config: OptimConfig, model: nn.Module):
 
 
 def get_init_weight_context(use_meta_tensor: bool = True, mesh: DeviceMesh = None):
+    """Get the appropriate weight initialization context.
+    
+    For FSDP (mesh is not None): Use meta tensor on non-primary ranks to save memory.
+    For DeepSpeed (mesh is None): Use CPU init on all ranks as DeepSpeed doesn't support meta tensors.
+    
+    Args:
+        use_meta_tensor: Whether to use meta tensor initialization (for memory optimization).
+        mesh: DeviceMesh for FSDP. If None, indicates non-FSDP backend (e.g., DeepSpeed).
+    
+    Returns:
+        A context manager for weight initialization.
+    """
     from accelerate import init_empty_weights
     
     cpu_init_weights = lambda: torch.device("cpu")
+    
     if use_meta_tensor:
         if mesh is None:
-            init_context = init_empty_weights if not is_rank0() else cpu_init_weights
+            # DeepSpeed or single-GPU: use CPU init on all ranks
+            # DeepSpeed doesn't support meta tensor initialization
+            init_context = cpu_init_weights
         else:
+            # FSDP: use meta tensor on non-primary ranks
             init_context = init_empty_weights if mesh.get_coordinate()[-1] != 0 else cpu_init_weights
     else:
         init_context = cpu_init_weights
+    
     return init_context


### PR DESCRIPTION
Thank you for this outstanding work on open source!

Use the example script and configure the Deepspeed training backend：
```
torchrun --nproc_per_node=8 -m rllava.train.pipeline.rlvr
config=examples/config.yaml
algorithm.adv_estimator=grpo
data.train_files=${TRAIN_SET}
data.val_files=${VAL_SET}
data.val_batch_size=1000
data.format_prompt=./examples/format_prompt/math.jinja
data.max_prompt_length=1024
actor.model.model_path=${MODEL_PATH}
rollout.vllm.gpu_memory_utilization=0.3
reward.reward_function=./examples/reward_function/math.py:compute_score
trainer.experiment_name=${NAME}
trainer.outputs_dir=${OUTPUT_DIR}
actor.strategy=deepspeed
actor.deepspeed.zero_stage=1
actor.deepspeed.enable_cpu_offload=false \
```

The following issues were encountered:

1. Using meta tensors to load models is not supported during model initialization.
2. An error occurred in the scope of `gradient_accumulation_steps` when updating actors.

The execution result after the fix is ​​shown below.
> step:1 - reward/accuracy:0.3499999940395355 - reward/format:0.16250000894069672 - reward/overall:0.33125001192092896 - critic/score/mean:0.33125001192092896 - critic/score/max:1.0 - critic/score/min:0.0 - critic/rewards/mean:0.33125001192092896 - critic/rewards/max:1.0 - critic/rewards/min:0.0 - critic/advantages/mean:-0.05640554800629616 - critic/advantages/max:1.7888498306274414 - critic/advantages/min:-1.7766554355621338 - critic/returns/mean:-0.05640554800629616 - critic/returns/max:1.7888498306274414 - critic/returns/min:-1.7766554355621338 - response_length/mean:385.4250183105469 - response_length/max:512.0 - response_length/min:137.0 - response_length/clip_ratio:0.26250001788139343 - prompt_length/mean:270.6875 - prompt_length/max:509.0 - prompt_length/min:110.0 - prompt_length/clip_ratio:0.0 - timing_s/gen:11.824235148960724 - timing_s/log_prob:1.9355037509812973 - timing_s/adv:20.364848234981764 - timing_s/update:5.083113020984456 - timing_s/step:39.375155429996084 - timing_per_token_ms/adv:0.3879831628528218 - timing_per_token_ms/gen:0.3834804160654059 - perf/total_num_tokens:52489 - perf/time_per_step:39.375155429996084 - perf/throughput:1333.048706139551 - actor/kl_loss:0.00022165013551784797 - actor/kl_coef:0.009999999999999998 - actor/pg_loss:0.0036668497836217285 - actor/pg_clipfrac_higher:0.0014110829535638914 - actor/ppo_kl:-5.82833228231161e-05 - actor/pg_clipfrac_lower:0.0 - actor/grad_norm:0.0 - perf/mfu/actor:0.20110879935304193 - perf/max_memory_allocated_gb:75.69074535369873 - perf/max_memory_reserved_gb:77.212890625 - perf/cpu_memory_used_gb:424.34054613113403 - actor/lr:1e-06

